### PR TITLE
shouldDirty and shouldValidate config options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ const useFormPersist = (
     exclude = [],
     include,
     onDataRestored,
-    dirty
+    validate = false,
+    dirty = false
   } = {}
 ) => {
   const values = watch(include)
@@ -23,7 +24,7 @@ const useFormPersist = (
         const shouldSet = !exclude.includes(key)
         if (shouldSet) {
           dataRestored[key] = values[key]
-          setValue(key, values[key], { shouldDirty: dirty })
+          setValue(key, values[key], { shouldValidate: validate, shouldDirty: dirty })
         }
       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ const useFormPersist = (
     storage = window.sessionStorage,
     exclude = [],
     include,
-    onDataRestored
+    onDataRestored,
+    dirty
   } = {}
 ) => {
   const values = watch(include)
@@ -22,7 +23,7 @@ const useFormPersist = (
         const shouldSet = !exclude.includes(key)
         if (shouldSet) {
           dataRestored[key] = values[key]
-          setValue(key, values[key])
+          setValue(key, values[key], { shouldDirty: dirty })
         }
       })
 


### PR DESCRIPTION
I added support for the shouldDirty and shouldValidate parameters (as 'dirty' and 'validate', respectively).
[https://react-hook-form.com/api#setValue](You can see documentation for them here).

Usage:
`useFormPersist('form', { watch, setValue }, { 
    storage: (store), 
    exclude: ['card'], 
    dirty: true, 
    validate: true 
});`

I found these both to be very useful.