### PR TITLE
shouldTouch config option

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ export interface FormPersistConfig {
   onDataRestored?: (data: any) => void;
   validate?: boolean;
   dirty?: boolean;
+  touch?: boolean;
   onTimeout?: () => void;
   timeout?: number;
 }
@@ -23,6 +24,7 @@ const useFormPersist = (
     onDataRestored,
     validate = false,
     dirty = false,
+    touch = false,
     onTimeout,
     timeout
   }: FormPersistConfig
@@ -53,7 +55,8 @@ const useFormPersist = (
           dataRestored[key] = values[key]
           setValue(key, values[key], {
             shouldValidate: validate,
-            shouldDirty: dirty
+            shouldDirty: dirty,
+            shouldTouch: touch
           })
         }
       })


### PR DESCRIPTION
Heey,
I added shouldTouch option to setValue config, according to https://react-hook-form.com/api/useform/setvalue its a bit update to https://github.com/tiaanduplessis/react-hook-form-persist/pull/10

usage:
`useFormPersist('form', { watch, setValue }, { storage: (store), exclude: ['card'], dirty: true, validate: true, touch: true });`