### PR TITLE
fix: add a cleanup function to useEffect that loads data from storage.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,6 +64,8 @@ const useFormPersist = (
       if (onDataRestored) {
         onDataRestored(dataRestored)
       }
+
+      return () => getStorage().setItem(name, JSON.stringify(dataRestored));
     }
   }, [
     storage,


### PR DESCRIPTION
Hi ! 

This fixes the issue with data not loaded from the storage as the Effects are fired twice in dev: https://beta.reactjs.org/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development

It simply creates a cleanup function that wirte to the storage after reading it.

Should fix: #18 

Hope it helps !