### PR TITLE
feat: bail if name is null

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ const useFormPersist = (
 
   const getStorage = () => storage || window.sessionStorage
 
-  const clearStorage = (name: string | null) => getStorage().removeItem(name)
+  const clearStorage = (name: string | null) => name && getStorage().removeItem(name)
 
   useEffect(() => {
     if (!name) return

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ export interface FormPersistConfig {
 }
 
 const useFormPersist = (
-  name: string,
+  name: string | null,
   {
     storage,
     watch,
@@ -33,9 +33,11 @@ const useFormPersist = (
 
   const getStorage = () => storage || window.sessionStorage
 
-  const clearStorage = () => getStorage().removeItem(name)
+  const clearStorage = (name: string | null) => getStorage().removeItem(name)
 
   useEffect(() => {
+    if (!name) return
+
     const str = getStorage().getItem(name)
 
     if (str) {
@@ -45,7 +47,7 @@ const useFormPersist = (
 
       if (timeout && (currTimestamp - _timestamp) > timeout) {
         onTimeout && onTimeout()
-        clearStorage()
+        clearStorage(name)
         return
       }
 
@@ -73,6 +75,7 @@ const useFormPersist = (
   ])
 
   useEffect(() => {
+    if (!name) return
 
     const values = exclude.length
       ? Object.entries(watchedValues)
@@ -88,8 +91,10 @@ const useFormPersist = (
     }
   }, [watchedValues, timeout])
 
+  if (!name) return
+
   return {
-    clear: () => getStorage().removeItem(name)
+    clear: () => clearStorage(name)
   }
 }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -13,10 +13,10 @@ beforeEach(() => {
 })
 
 
-const Form = ({ onSubmit = () => { }, config = {} }: { onSubmit?: any, config?: Omit<FormPersistConfig, 'watch' | 'setValue'> }) => {
+const Form = ({ onSubmit = () => {}, config = {}, name = STORAGE_KEY }: { onSubmit?: any, config?: Omit<FormPersistConfig, 'watch' | 'setValue'>, name?: string | null }) => {
   const { register, handleSubmit, watch, setValue } = useForm()
 
-  useFormPersist(STORAGE_KEY, { watch, setValue, ...config })
+  useFormPersist(name, { watch, setValue, ...config })
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -52,6 +52,16 @@ describe('react-hook-form-persist', () => {
       bar: '',
       baz: ''
     })
+  })
+
+  test('should not persist when no name is present', async () => {
+    const spy = vi.spyOn(Storage.prototype, 'setItem')
+
+    render(<Form name={null} />)
+
+    await userEvent.type(screen.getByLabelText('foo:'), 'foo')
+
+    expect(spy).not.toHaveBeenCalled()
   })
 
   test('should retrieve stored fields', async () => {


### PR DESCRIPTION
Added check (with test) to ensure `name` is set. If not, return. This would allow for setting up `useFormPersist` conditionally with a prop:

```js
const MyComponent = ({ persistKey }) => {
	const { watch, setValue } = useForm();

	useFormPersist(persistKey, {
		setValue,
		watch,
	});

	return (
		<form>
			...
		</form>
	);
};
```
Using `MyComponent` without `useFormPersist`:
```js
<MyComponent persistKey={null} />`
```

Fixes #30 