### PR TITLE
Fix/fix development error with react strict mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,7 @@ const useFormPersist = (
         .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
       : Object.assign({}, watchedValues)
 
-    if (Object.entries(values).length ) {
+    if (Object.entries(values).length) {
       if (timeout !== undefined) {
         values._timestamp = Date.now()
       }


### PR DESCRIPTION
Hello.

This fixes a bug that happens when using `react-hook-form` with `defaultValues` option.

https://beta.reactjs.org/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development

It basically makes sure it only runs once using the good old _mounted ref.

Should fix: https://github.com/tiaanduplessis/react-hook-form-persist/issues/18

I also added a test.