### PR TITLE
feat: is synchronized with form state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { SetFieldValue } from 'react-hook-form'
 
 export interface FormPersistConfig {
@@ -35,6 +35,8 @@ const useFormPersist = (
 
   const clearStorage = () => getStorage().removeItem(name)
 
+  const [isSynchronized, setIsSynchronized] = useState(false)
+
   useEffect(() => {
     const str = getStorage().getItem(name)
 
@@ -65,6 +67,7 @@ const useFormPersist = (
         onDataRestored(dataRestored)
       }
     }
+    setIsSynchronized(true)
   }, [
     storage,
     name,
@@ -89,6 +92,7 @@ const useFormPersist = (
   }, [watchedValues, timeout])
 
   return {
+    isSynchronized,
     clear: () => getStorage().removeItem(name)
   }
 }


### PR DESCRIPTION
### Provide a way to find out if synchronization with `localstorage` is complete.

#### Issue
On first launch this triggers two renders, in my case it’s make two requests to the API.

#### Solution
After synchronizing the `localstorage` data and the form state, update the value of the `isSynchronized` state to true, so I can check it in my code and do the request.